### PR TITLE
[STUDIO-7889] [KSR] Official Support Request for Plugin with stop Implementation in Jenkins Integration

### DIFF
--- a/src/main/java/com/katalon/jenkins/plugin/ExecuteKatalonStudioTask.java
+++ b/src/main/java/com/katalon/jenkins/plugin/ExecuteKatalonStudioTask.java
@@ -88,7 +88,7 @@ public class ExecuteKatalonStudioTask extends Builder implements SimpleBuildStep
             throws InterruptedException, IOException {
 
         // Check for interruption before starting
-        if (Thread.currentThread().isInterrupted()) {
+        if (isInterrupted()) {
             buildListener.getLogger().println("Build was cancelled before Katalon execution started");
             throw new InterruptedException("Build was cancelled");
         }
@@ -104,7 +104,7 @@ public class ExecuteKatalonStudioTask extends Builder implements SimpleBuildStep
             throws InterruptedException, IOException {
 
         // Check for interruption before starting
-        if (Thread.currentThread().isInterrupted()) {
+        if (isInterrupted()) {
             taskListener.getLogger().println("Build was cancelled before Katalon execution started");
             throw new InterruptedException("Build was cancelled");
         }
@@ -152,5 +152,9 @@ public class ExecuteKatalonStudioTask extends Builder implements SimpleBuildStep
             save();
             return super.configure(req, formData);
         }
+    }
+
+    private static boolean isInterrupted() {
+        return Thread.currentThread().isInterrupted();
     }
 }

--- a/src/main/java/com/katalon/jenkins/plugin/ExecuteKatalonStudioTask.java
+++ b/src/main/java/com/katalon/jenkins/plugin/ExecuteKatalonStudioTask.java
@@ -85,7 +85,14 @@ public class ExecuteKatalonStudioTask extends Builder implements SimpleBuildStep
 
     @Override
     public boolean perform(AbstractBuild<?, ?> abstractBuild, Launcher launcher, BuildListener buildListener)
-        throws InterruptedException, IOException {
+            throws InterruptedException, IOException {
+
+        // Check for interruption before starting
+        if (Thread.currentThread().isInterrupted()) {
+            buildListener.getLogger().println("Build was cancelled before Katalon execution started");
+            throw new InterruptedException("Build was cancelled");
+        }
+
         FilePath workspace = abstractBuild.getWorkspace();
         EnvVars buildEnvironment = abstractBuild.getEnvironment(buildListener);
         return doPerform(workspace, buildEnvironment, launcher, buildListener);
@@ -94,24 +101,37 @@ public class ExecuteKatalonStudioTask extends Builder implements SimpleBuildStep
     @Override
     public void perform(@Nonnull Run<?, ?> run, @Nonnull FilePath filePath, @Nonnull Launcher launcher,
                         @Nonnull TaskListener taskListener)
-        throws InterruptedException, IOException {
+            throws InterruptedException, IOException {
+
+        // Check for interruption before starting
+        if (Thread.currentThread().isInterrupted()) {
+            taskListener.getLogger().println("Build was cancelled before Katalon execution started");
+            throw new InterruptedException("Build was cancelled");
+        }
+
         EnvVars buildEnvironment = run.getEnvironment(taskListener);
         doPerform(filePath, buildEnvironment, launcher, taskListener);
     }
 
     private boolean doPerform(FilePath workspace, EnvVars buildEnvironment,
                               Launcher launcher, TaskListener taskListener)
-        throws IOException, InterruptedException {
-        return ExecuteKatalonStudioHelper.executeKatalon(
-            workspace,
-            buildEnvironment,
-            launcher,
-            taskListener,
-            version,
-            location,
-            executeArgs,
-            x11Display,
-            xvfbConfiguration);
+            throws IOException, InterruptedException {
+
+        try {
+            return ExecuteKatalonStudioHelper.executeKatalon(
+                    workspace,
+                    buildEnvironment,
+                    launcher,
+                    taskListener,
+                    version,
+                    location,
+                    executeArgs,
+                    x11Display,
+                    xvfbConfiguration);
+        } catch (InterruptedException e) {
+            taskListener.getLogger().println("Katalon execution was interrupted due to build cancellation");
+            throw e; // Re-throw to ensure proper build status
+        }
     }
 
     @Symbol("executeKatalon")

--- a/src/main/java/com/katalon/jenkins/plugin/helper/ExecuteKatalonStudioHelper.java
+++ b/src/main/java/com/katalon/jenkins/plugin/helper/ExecuteKatalonStudioHelper.java
@@ -12,6 +12,7 @@ import jenkins.security.MasterToSlaveCallable;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 public class ExecuteKatalonStudioHelper {
 
@@ -24,45 +25,152 @@ public class ExecuteKatalonStudioHelper {
             String location,
             String executeArgs,
             String x11Display,
-            String xvfbConfiguration) {
+            String xvfbConfiguration) throws InterruptedException {
         Logger logger = new JenkinsLogger(taskListener);
         try {
             VirtualChannel channel = launcher.getChannel();
             if (channel == null) {
                 throw new Exception("Channel not found!");
             }
-            return channel.call(new MasterToSlaveCallable<Boolean, Exception>() {
-                @Override
-                public Boolean call() throws Exception {
-
-                    Logger logger = new JenkinsLogger(taskListener);
-
-                    if (workspace != null) {
-                        String workspaceLocation = workspace.getRemote();
-
-                        if (workspaceLocation != null) {
-                            Map<String, String> environmentVariables = new HashMap<>();
-                            environmentVariables.putAll(System.getenv());
-                            buildEnvironment.entrySet()
-                                    .forEach(entry -> environmentVariables.put(entry.getKey(), entry.getValue()));
-                            return KatalonUtils.executeKatalon(
-                                logger,
-                                version,
-                                location,
-                                workspaceLocation,
-                                executeArgs,
-                                x11Display,
-                                xvfbConfiguration,
-                                environmentVariables);
-                        }
-                    }
-                    return true;
-                }
-            });
+            return channel.call(new InterruptibleKatalonCallable(
+                    taskListener, workspace, buildEnvironment, logger, version,
+                    location, executeArgs, x11Display, xvfbConfiguration));
+        } catch (InterruptedException e) {
+            logger.info("Katalon execution was interrupted");
+            throw e; // Re-throw InterruptedException to maintain cancellation behavior
         } catch (Exception e) {
             String stackTrace = Throwables.getStackTraceAsString(e);
             logger.info(stackTrace);
             return false;
+        }
+    }
+
+    private static class InterruptibleKatalonCallable extends MasterToSlaveCallable<Boolean, Exception> {
+        private final TaskListener taskListener;
+        private final FilePath workspace;
+        private final EnvVars buildEnvironment;
+        private final Logger logger;
+        private final String version;
+        private final String location;
+        private final String executeArgs;
+        private final String x11Display;
+        private final String xvfbConfiguration;
+        private final AtomicBoolean cancelled = new AtomicBoolean(false);
+
+        public InterruptibleKatalonCallable(TaskListener taskListener, FilePath workspace,
+                                            EnvVars buildEnvironment, Logger logger, String version, String location,
+                                            String executeArgs, String x11Display, String xvfbConfiguration) {
+            this.taskListener = taskListener;
+            this.workspace = workspace;
+            this.buildEnvironment = buildEnvironment;
+            this.logger = logger;
+            this.version = version;
+            this.location = location;
+            this.executeArgs = executeArgs;
+            this.x11Display = x11Display;
+            this.xvfbConfiguration = xvfbConfiguration;
+        }
+
+        @Override
+        public Boolean call() throws Exception {
+            Logger logger = new JenkinsLogger(taskListener);
+
+            // Check for interruption at the start
+            if (Thread.currentThread().isInterrupted()) {
+                logger.info("Thread was interrupted before Katalon execution started");
+                throw new InterruptedException("Execution was cancelled");
+            }
+
+            if (workspace != null) {
+                String workspaceLocation = workspace.getRemote();
+
+                if (workspaceLocation != null) {
+                    Map<String, String> environmentVariables = new HashMap<>();
+                    environmentVariables.putAll(System.getenv());
+                    buildEnvironment.entrySet()
+                            .forEach(entry -> environmentVariables.put(entry.getKey(), entry.getValue()));
+
+                    // Check for interruption before starting Katalon
+                    if (Thread.currentThread().isInterrupted()) {
+                        logger.info("Thread was interrupted before calling KatalonUtils.executeKatalon");
+                        throw new InterruptedException("Execution was cancelled");
+                    }
+                    try {
+                        // Create a wrapper that can be interrupted
+                        return executeKatalonWithInterruption(
+                                logger, version, location, workspaceLocation,
+                                executeArgs, x11Display, xvfbConfiguration, environmentVariables);
+                    } catch (InterruptedException e) {
+                        logger.info("Katalon execution was interrupted due to build cancellation");
+                        cancelled.set(true);
+                        throw e;
+                    }
+                }
+            }
+            return true;
+        }
+
+        private Boolean executeKatalonWithInterruption(
+                Logger logger, String version, String location, String workspaceLocation,
+                String executeArgs, String x11Display, String xvfbConfiguration,
+                Map<String, String> environmentVariables) throws Exception {
+
+            // Create a thread to run Katalon execution
+            final Exception[] executionException = new Exception[1];
+            final Boolean[] result = new Boolean[1];
+
+            Thread katalonThread = new Thread(() -> {
+                try {
+                    result[0] = KatalonUtils.executeKatalon(
+                            logger, version, location, workspaceLocation,
+                            executeArgs, x11Display, xvfbConfiguration, environmentVariables);
+                } catch (Exception e) {
+                    executionException[0] = e;
+                }
+            });
+
+            katalonThread.start();
+
+            // Monitor for interruption while Katalon is running
+            while (katalonThread.isAlive()) {
+                if (Thread.currentThread().isInterrupted()) {
+                    logger.info("Build cancellation detected, interrupting Katalon execution");
+
+                    // Interrupt the Katalon thread
+                    katalonThread.interrupt();
+
+                    // Wait a bit for graceful shutdown
+                    try {
+                        katalonThread.join(5000); // Wait up to 5 seconds
+                    } catch (InterruptedException ie) {
+                        // If we're interrupted while waiting, force stop
+                        Thread.currentThread().interrupt();
+                    }
+
+                    // If thread is still alive, we need to force terminate
+                    if (katalonThread.isAlive()) {
+                        logger.info("Katalon execution did not stop gracefully, attempting force termination");
+                        // Note: In a real implementation, you might need to kill the Katalon process
+                        // This would require access to the process ID from KatalonUtils
+                    }
+
+                    throw new InterruptedException("Katalon execution was cancelled");
+                }
+
+                try {
+                    Thread.sleep(1000); // Check every second
+                } catch (InterruptedException e) {
+                    // If interrupted while sleeping, interrupt Katalon and exit
+                    katalonThread.interrupt();
+                    throw e;
+                }
+            }
+
+            // Check if there was an exception during execution
+            if (executionException[0] != null) {
+                throw executionException[0];
+            }
+            return result[0] != null ? result[0] : false;
         }
     }
 }

--- a/src/main/java/com/katalon/jenkins/plugin/helper/ExecuteKatalonStudioHelper.java
+++ b/src/main/java/com/katalon/jenkins/plugin/helper/ExecuteKatalonStudioHelper.java
@@ -146,14 +146,6 @@ public class ExecuteKatalonStudioHelper {
                         // If we're interrupted while waiting, force stop
                         Thread.currentThread().interrupt();
                     }
-
-                    // If thread is still alive, we need to force terminate
-                    if (katalonThread.isAlive()) {
-                        logger.info("Katalon execution did not stop gracefully, attempting force termination");
-                        // Note: In a real implementation, you might need to kill the Katalon process
-                        // This would require access to the process ID from KatalonUtils
-                    }
-
                     throw new InterruptedException("Katalon execution was cancelled");
                 }
 


### PR DESCRIPTION
### Description

- Adds official support for stopping Katalon Studio executions in the Jenkins plugin by making the remote call interruptible and surfacing cancellation early in the build steps.


https://github.com/user-attachments/assets/f2175991-7c24-4c93-bdea-967cc209b3ef



### References

[STUDIO-7889](https://katalon.atlassian.net/browse/STUDIO-7889)

[STUDIO-7889]: https://katalon.atlassian.net/browse/STUDIO-7889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ